### PR TITLE
.travis.yml: remove nightly 2018 variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: rust
 cache: cargo
 rust:
   - nightly
-  - nightly-2018-12-04
   - beta
   - stable
 matrix:


### PR DESCRIPTION
It's currently failing, and presumably we don't need to test nightlies
from 2018 anymore.